### PR TITLE
Fixed profile status filter not working

### DIFF
--- a/src/app/dashboard/admin/_component/compact-table.tsx
+++ b/src/app/dashboard/admin/_component/compact-table.tsx
@@ -264,6 +264,9 @@ export const columns: ColumnDef<User>[] = [
         </Select>
       );
     },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id));
+    },
   },
   {
     accessorKey: "startDate",


### PR DESCRIPTION
## Changes
- Added `filterFn` to the `profileStatus` column.

## Tests

### No filters
![image](https://github.com/user-attachments/assets/b69c5366-77e2-4bf7-ae6b-bb6b9c6c0a7c)

### Filter without any matching row
![image](https://github.com/user-attachments/assets/8cd273b2-d68d-4afd-ac20-f4490ae7f5d2)

### Filter with matching row
![image](https://github.com/user-attachments/assets/61d21103-39da-431c-9b42-022f6f98c66c)
![image](https://github.com/user-attachments/assets/78f4ccce-c136-4074-b54f-3f1d5fec228c)
